### PR TITLE
Fix hang when subprocess output is too long

### DIFF
--- a/Sources/SwiftShell/Shell.swift
+++ b/Sources/SwiftShell/Shell.swift
@@ -40,10 +40,10 @@ public struct Shell {
         task.standardOutput = outputPipe
         task.standardError = errorPipe
         task.launch()
-        task.waitUntilExit()
 
         let outputMessage = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?.trimmingCharacters(in: .newlines)
         let errorMessage = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?.trimmingCharacters(in: .newlines)
+        task.waitUntilExit()
 
         let status = task.terminationStatus
         if status == 0 {

--- a/Tests/SwiftShellTests/SwiftShellTests.swift
+++ b/Tests/SwiftShellTests/SwiftShellTests.swift
@@ -22,6 +22,12 @@ final class SwiftShellTests: XCTestCase {
         XCTAssertEqual(result, "test")
     }
 
+    func testLongOutput() throws {
+        let longText = (1...100000).map { _ in "=" }.joined(separator: "")
+        let result = try shell("echo '\(longText)'")
+        XCTAssertEqual(result, longText)
+    }
+
     func testThrowsWhenInvalidCommandCalled() throws {
         XCTAssertThrowsError(try shell("taji-taji/swift-shell/invalid-command"))
     }


### PR DESCRIPTION
I was trying to get https://github.com/taji-taji/DangerSwiftPeriphery working, but it was hanging. After some investigation I realised it is because of long output.

See this link:
https://stackoverflow.com/questions/33423993/hanging-nstask-using-waituntilexit

and also this test in another library:

https://github.com/kareman/SwiftShell/blob/master/Tests/SwiftShellTests/Command_Tests.swift#L86